### PR TITLE
fix: improve interval handling and cleanup in fetch scheduling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -158,12 +158,16 @@ export const FlagsProvider: FC<FlagsProviderProps> = ({
     }
 
     fetchAndSchedule().catch(console.error)
-    setInterval(fetchAndSchedule, (intervalAllowed * 1000), {
-      signal: ac.signal,
-    });
+    const intervalDuration = (intervalAllowed || 900) * 1000;
+    const intervalId = setInterval(() => {
+      fetchAndSchedule().catch(console.error);
+    }, intervalDuration);
+
+    // Cleanup function clears the interval and aborts fetch
     return () => {
-      ac.abort()
-    }
+      clearInterval(intervalId);
+      ac.abort();
+    };
   }, [fetchFlags, intervalAllowed]);
 
   const toggleFlag = useCallback((flagName: string) => {


### PR DESCRIPTION
Refactor setInterval usage to use a callback function instead of
passing arguments directly. Introduce intervalId to enable proper
cleanup by clearing the interval on unmount. Also ensure the abort
controller is called during cleanup to cancel ongoing fetch requests.

These changes prevent potential memory leaks and ensure fetches are
properly managed when the component unmounts or dependencies change.