### PR TITLE
✨ feat: use stable 900s default, manage interval lifecycle and avoid redundant updates

### DIFF
--- a/__tests__/FlagsProvider.test.tsx
+++ b/__tests__/FlagsProvider.test.tsx
@@ -296,6 +296,7 @@ describe('FlagsProvider', () => {
     it('should clean up interval on unmount', async () => {
       jest.useFakeTimers();
       const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
       setupFetchMock();
 
       const { unmount } = render(
@@ -306,6 +307,11 @@ describe('FlagsProvider', () => {
 
       await waitFor(() => {
         expect(global.fetch).toHaveBeenCalled();
+      });
+
+      // Wait for the interval to be set up after initial fetch
+      await waitFor(() => {
+        expect(setIntervalSpy).toHaveBeenCalled();
       });
 
       unmount();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -260,7 +260,13 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
 
     // Only start interval after initial fetch is done
     if (!initialFetchDoneRef.current) {
-      return;
+      // Still return cleanup function even if not starting interval yet
+      return () => {
+        if (intervalIdRef.current) {
+          clearInterval(intervalIdRef.current);
+          intervalIdRef.current = null;
+        }
+      };
     }
 
     // Start new interval with current intervalAllowed value

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,13 +72,14 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
   } = options;
 
   const [flags, setFlags] = useState<Flags>({});
-  const [intervalAllowed, setIntervalAllowed] = useState(60);
+  const [intervalAllowed, setIntervalAllowed] = useState(900); // Default to 900s fallback
   const [secretMenu, setSecretMenu] = useState<string[]>([]);
   const [localOverrides, setLocalOverrides] = useAtom(localFlagSettings);
   const [secretMenuStyles, setSecretMenuStyles] = useState<SecretMenuStyle[]>([]);
   const cache = new Cache();
   const initialFetchDoneRef = useRef(false)
-  const intervalAllowedRef = useRef(60);
+  const intervalAllowedRef = useRef(900); // Default to 900s fallback
+  const intervalIdRef = useRef<NodeJS.Timeout | null>(null);
 
   const fetchFlags = useCallback(async () => {
     const cacheKey = `flags_${projectId}_${agentId}_${environmentId}`;
@@ -164,9 +165,11 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
         throw new Error('Invalid response structure');
       }
       
-      const newInterval = data.intervalAllowed ?? 900;
-      setIntervalAllowed(newInterval);
-      intervalAllowedRef.current = newInterval;
+      const newInterval = data.intervalAllowed ?? 60; // Use 60s if server provides it
+      if (newInterval !== intervalAllowedRef.current) {
+        setIntervalAllowed(newInterval);
+        intervalAllowedRef.current = newInterval;
+      }
       
       if (data.secretMenu) {
         setSecretMenu(data.secretMenu.sequence || []);
@@ -228,7 +231,7 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
         }
       }
     }
-  }, [flagsURL, intervalAllowed, agentId, projectId, environmentId, enableLogs, cache, flags, localOverrides, setFlags]);
+  }, [flagsURL, agentId, projectId, environmentId, enableLogs, cache, flags, localOverrides, setFlags]);
 
   // Initial fetch effect
   useEffect(() => {
@@ -247,49 +250,42 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
     };
   }, [fetchFlags]);
 
-  // Interval effect - separate to avoid re-creating when intervalAllowed changes
+  // Interval effect - responds to intervalAllowed changes
   useEffect(() => {
-    let intervalId: NodeJS.Timeout | null = null;
-    
-    const startInterval = () => {
-      // Clear any existing interval
-      if (intervalId) {
-        clearInterval(intervalId);
-      }
-      
-      const intervalDuration = (intervalAllowedRef.current || 900) * 1000;
-      intervalId = setInterval(() => {
-        fetchFlags().catch(console.error);
-      }, intervalDuration);
-    };
-
-    // Start the interval after initial fetch is done
-    if (initialFetchDoneRef.current) {
-      startInterval();
-    } else {
-      // Wait for initial fetch to complete
-      const checkInterval = setInterval(() => {
-        if (initialFetchDoneRef.current) {
-          clearInterval(checkInterval);
-          startInterval();
-        }
-      }, 100);
-      
-      return () => {
-        clearInterval(checkInterval);
-        if (intervalId) {
-          clearInterval(intervalId);
-        }
-      };
+    // Clear any existing interval
+    if (intervalIdRef.current) {
+      clearInterval(intervalIdRef.current);
+      intervalIdRef.current = null;
     }
+
+    // Only start interval after initial fetch is done
+    if (!initialFetchDoneRef.current) {
+      return;
+    }
+
+    // Start new interval with current intervalAllowed value
+    // Always use intervalAllowed which defaults to 900s if server fails
+    const intervalDuration = intervalAllowed * 1000;
+    if (enableLogs) {
+      logIt(`Setting up interval with duration: ${intervalDuration}ms (${intervalAllowed}s)`);
+    }
+    
+    intervalIdRef.current = setInterval(() => {
+      fetchFlags().catch((error) => {
+        if (enableLogs) {
+          logIt("Interval fetch error, will retry in next interval:", error);
+        }
+      });
+    }, intervalDuration);
 
     // Cleanup function
     return () => {
-      if (intervalId) {
-        clearInterval(intervalId);
+      if (intervalIdRef.current) {
+        clearInterval(intervalIdRef.current);
+        intervalIdRef.current = null;
       }
     };
-  }, [fetchFlags]);
+  }, [intervalAllowed, initialFetchDoneRef.current, fetchFlags, enableLogs]);
 
   const toggleFlag = useCallback((flagName: string) => {
     setLocalOverrides(prevOverrides => {


### PR DESCRIPTION
- Set default timeout to 900 seconds
- Properly manage interval lifecycle to start/stop as needed
- Prevent redundant updates by avoiding unnecessary re-renders or state changes