### PR TITLE
fix: scope flags error boundary to flags UI

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -356,14 +356,24 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
       <FlagsContext.Provider value={effectiveFlags}>
         {children}
         {secretMenu?.length >= 1 && (
-          <SecretMenu
-            secretMenu={secretMenu}
-            flags={effectiveFlags}
-            toggleFlag={toggleFlag}
-            secretMenuStyles={secretMenuStyles}
-            resetFlags={resetFlags}
-            isFlag={isFlag}
-          />
+          <ErrorBoundary
+            fallback={
+              <div>Feature flags system encountered an error. Using default values.</div>
+            }
+            onError={(error, errorInfo) => {
+              console.error("FlagsProvider SecretMenu Error:", error, errorInfo);
+            }}
+            isolate
+          >
+            <SecretMenu
+              secretMenu={secretMenu}
+              flags={effectiveFlags}
+              toggleFlag={toggleFlag}
+              secretMenuStyles={secretMenuStyles}
+              resetFlags={resetFlags}
+              isFlag={isFlag}
+            />
+          </ErrorBoundary>
         )}
       </FlagsContext.Provider>
     </SetFlagsContext.Provider>
@@ -371,18 +381,7 @@ const FlagsProviderInner: FC<FlagsProviderProps> = ({
 };
 
 export const FlagsProvider: FC<FlagsProviderProps> = (props) => {
-  return (
-    <ErrorBoundary 
-      fallback={
-        <div>Feature flags system encountered an error. Using default values.</div>
-      }
-      onError={(error, errorInfo) => {
-        console.error('FlagsProvider Error:', error, errorInfo);
-      }}
-    >
-      <FlagsProviderInner {...props} />
-    </ErrorBoundary>
-  );
+  return <FlagsProviderInner {...props} />;
 };
 
 export const useFlags = () => {


### PR DESCRIPTION
## Summary
- stop wrapping all consumer app children in the `FlagsProvider` error boundary
- keep the flags fallback only around the library-owned `SecretMenu`
- let unrelated app errors bubble normally instead of being mislabeled as feature-flags failures

## Problem
A consumer app error like missing `QueryClientProvider` was being caught by the top-level `FlagsProvider` boundary and rendered as:

`Feature flags system encountered an error. Using default values.`

That message is wrong for non-flags errors and hides the real application failure.

## Testing
- `bun x eslint src/index.tsx`
- `bun x tsc --noEmit`
